### PR TITLE
feat: 로그인/회원가입 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-redux": "^8.1.1",
         "react-router-dom": "^6.14.1",
         "react-scripts": "5.0.1",
+        "redux-persist": "^6.0.0",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
       },
@@ -14271,6 +14272,14 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
       }
     },
     "node_modules/redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-redux": "^8.1.1",
     "react-router-dom": "^6.14.1",
     "react-scripts": "5.0.1",
+    "redux-persist": "^6.0.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import Routes from 'routes/Routes';
+import TempHeader from './components/common/TempHeader';
 
 function App() {
   return (
     <div className='App'>
+      <TempHeader />
       <Routes />
     </div>
   );

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,11 +1,11 @@
 import request from './axios';
 
 export const signUp = async (state) => {
-  const response = await request.post('/auth/singup', state);
+  const response = await request.post('/auth/signup', state);
   return response.data;
 };
 
 export const signIn = async (state) => {
-  const response = await request.post('/auth/singIn', state);
+  const response = await request.post('/auth/signin', state);
   return response.data;
 };

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,16 +1,24 @@
 import axios from 'axios';
 import { store } from '../store';
 
-const accessToken = store.getState().auth.accessToken;
-
 const request = axios.create({
   baseURL: process.env.REACT_APP_API + '/api',
   headers: {
     'Content-Type': 'application/json',
     'x-api-key': process.env.REACT_APP_KEY,
     Accept: '*/*',
-    Authorization: `Bearer ${accessToken}`,
   },
 });
+
+request.interceptors.request.use(
+  (config) => {
+    const accessToken = store.getState().auth.accessToken;
+    config.headers.Authorization = `Bearer ${accessToken}`;
+    return config;
+  },
+  (err) => {
+    return Promise.reject(err);
+  },
+);
 
 export default request;

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,4 +1,7 @@
 import axios from 'axios';
+import { store } from '../store';
+
+const accessToken = store.getState().auth.accessToken;
 
 const request = axios.create({
   baseURL: process.env.REACT_APP_API + '/api',
@@ -6,7 +9,7 @@ const request = axios.create({
     'Content-Type': 'application/json',
     'x-api-key': process.env.REACT_APP_KEY,
     Accept: '*/*',
-    Authorization: 'Bearer ', //로그인 되면 세션에서 토큰을 가져와야 할거 같아요!!
+    Authorization: `Bearer ${accessToken}`,
   },
 });
 

--- a/src/components/auth/AuthInput.tsx
+++ b/src/components/auth/AuthInput.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Input } from '../common/Input';
+
+interface AuthInput {
+  readonly label?: string;
+  readonly id: string;
+  readonly type?: string;
+  value: string;
+  readonly placeholder: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  isError?: boolean;
+  readonly errorText?: string;
+  readonly className?: string;
+}
+
+const AuthInput = ({
+  label,
+  id,
+  type,
+  value,
+  placeholder,
+  onChange,
+  isError,
+  errorText,
+  className,
+}: AuthInput) => {
+  return (
+    <div className={className ? className : 'mb-6'}>
+      <label htmlFor={id} className='block mb-1 text-subtitle-1 text-left'>
+        {label}
+      </label>
+      <Input
+        id={id}
+        type={type}
+        value={value}
+        placeHolder={placeholder}
+        onChange={onChange}
+        disabled={false}
+      />
+      {isError && (
+        <p className='mt-1 text-caption-2 text-danger'>{errorText}</p>
+      )}
+    </div>
+  );
+};
+
+export default AuthInput;

--- a/src/components/auth/HeadingText.tsx
+++ b/src/components/auth/HeadingText.tsx
@@ -1,0 +1,9 @@
+interface HeadingText {
+  text: string;
+}
+
+const HeadingText = ({ text }: HeadingText) => {
+  return <h2 className='mb-10 text-heading-2 text-center'>{text}</h2>;
+};
+
+export default HeadingText;

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -65,7 +65,7 @@ const LoginForm = () => {
   return (
     <>
       <form className='max-w-md mx-auto' onSubmit={handleSubmit}>
-        <div className='px-5 py-6 border border-[#2D4053] bg-white shadow-card-1'>
+        <div className='px-5 py-6 border border-blue-gray-880 bg-white shadow-card-1'>
           <AuthInput
             label='아이디'
             id='id'

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,0 +1,100 @@
+import React, { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from 'react-query';
+import { useDispatch } from 'react-redux';
+import { signIn } from '../../api/auth';
+import { AppDispatch } from '../../store';
+import { login } from '../../store/auth';
+
+import AuthInput from './AuthInput';
+import { LargeButton, SmallButton } from '../common/Button';
+
+const LoginForm = () => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch<AppDispatch>();
+  const [id, setId] = useState('');
+  const [password, setPassword] = useState('');
+  const [isIdError, setIsIdError] = useState(false);
+  const [isPasswordError, setIsPasswordError] = useState(false);
+
+  const loginMutation = useMutation(signIn, {
+    onError: () => {
+      alert('아이디 또는 비밀번호를 잘못 입력했습니다. 다시 확인해주세요.');
+      setId('');
+      setPassword('');
+    },
+    onSuccess: (data) => {
+      dispatch(login(data.data));
+      navigate('/');
+    },
+  });
+
+  const handleIdChange = useCallback((value: string) => {
+    setId(value);
+
+    if (value.length < 1) {
+      setIsIdError(true);
+    } else {
+      setIsIdError(false);
+    }
+  }, []);
+
+  const handlePasswordChange = useCallback((value: string) => {
+    setPassword(value);
+
+    if (value.length < 1) {
+      setIsPasswordError(true);
+    } else {
+      setIsPasswordError(false);
+    }
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!id) {
+      setIsIdError(true);
+    }
+    if (!password) {
+      setIsPasswordError(true);
+    }
+    if (id && password) {
+      loginMutation.mutate({ loginId: id, password });
+    }
+  };
+
+  return (
+    <>
+      <form className='max-w-md mx-auto' onSubmit={handleSubmit}>
+        <div className='px-5 py-6 border border-[#2D4053] bg-white shadow-card-1'>
+          <AuthInput
+            label='아이디'
+            id='id'
+            value={id}
+            placeholder='아이디'
+            onChange={(e) => handleIdChange(e.target.value)}
+            isError={isIdError}
+            errorText='아이디를 입력해주세요.'
+          />
+          <AuthInput
+            label='비밀번호'
+            id='password'
+            type='password'
+            value={password}
+            placeholder='비밀번호'
+            onChange={(e) => handlePasswordChange(e.target.value)}
+            isError={isPasswordError}
+            errorText='비밀번호를 입력해주세요.'
+          />
+        </div>
+        <div className='mt-14 text-center'>
+          <LargeButton text='로그인' />
+        </div>
+      </form>
+      <div className='mt-8 text-center'>
+        <SmallButton text='회원가입' onClick={() => navigate('/signup')} />
+      </div>
+    </>
+  );
+};
+
+export default LoginForm;

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -1,0 +1,158 @@
+import React, { useCallback, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from 'react-query';
+import { AxiosError } from 'axios';
+import { signUp } from '../../api/auth';
+import AuthInput from './AuthInput';
+import { LargeButton } from '../common/Button';
+
+const SignupForm = () => {
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [id, setId] = useState('');
+  const [password, setPassword] = useState('');
+  const [passwordConfirm, setPasswordConfirm] = useState('');
+  const [isNameError, setIsNameError] = useState(false);
+  const [isIdError, setIsIdError] = useState(false);
+  const [isPasswordError, setIsPasswordError] = useState(false);
+  const [isPasswordConfirmError, setIsPasswordConfirmError] = useState(false);
+
+  const signupMutation = useMutation(signUp, {
+    onError: (error: AxiosError) => {
+      const errorData = error?.response?.data;
+      alert(`회원가입에 실패했습니다. ${errorData && errorData['message']}`);
+    },
+    onSuccess: () => {
+      alert('🎉가입되었습니다.🎉');
+      navigate('/login');
+    },
+  });
+
+  const handleNameChange = useCallback((value: string) => {
+    setName(value);
+
+    if (value.length >= 2 && value.length <= 5) {
+      setIsNameError(false);
+    } else {
+      setIsNameError(true);
+    }
+  }, []);
+
+  const handleIdChange = useCallback((value: string) => {
+    const idRegex = /^[A-Za-z0-9]{6,}$/; // 영문, 숫자 조합 6자 이상
+    setId(value);
+
+    if (idRegex.test(value)) {
+      setIsIdError(false);
+    } else {
+      setIsIdError(true);
+    }
+  }, []);
+
+  const handlePasswordChange = useCallback((value: string) => {
+    const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9]).{4,}$/; // 영문, 숫자 포함 4자 이상
+    setPassword(value);
+
+    if (passwordRegex.test(value)) {
+      setIsPasswordError(false);
+    } else {
+      setIsPasswordError(true);
+    }
+  }, []);
+
+  const handlePasswordConfirmChange = useCallback(
+    (value: string) => {
+      setPasswordConfirm(value);
+
+      if (password === value) {
+        setIsPasswordConfirmError(false);
+      } else {
+        setIsPasswordConfirmError(true);
+      }
+    },
+    [password],
+  );
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!name) {
+      setIsNameError(true);
+    }
+    if (!id) {
+      setIsIdError(true);
+    }
+    if (!password) {
+      setIsPasswordError(true);
+    }
+    if (!passwordConfirm) {
+      setIsPasswordConfirmError(true);
+    }
+    if (
+      name &&
+      id &&
+      password &&
+      passwordConfirm &&
+      !isNameError &&
+      !isIdError &&
+      !isPasswordError &&
+      !isPasswordConfirmError
+    ) {
+      signupMutation.mutate({
+        loginId: id,
+        name,
+        password,
+      });
+    }
+  };
+
+  return (
+    <form className='max-w-md mx-auto' onSubmit={handleSubmit}>
+      <div className='px-5 py-6 border border-blue-gray-880 bg-white shadow-card-1'>
+        <AuthInput
+          label='이름'
+          id='name'
+          type='text'
+          value={name}
+          placeholder='이름을 입력해주세요.'
+          onChange={(e) => handleNameChange(e.target.value)}
+          isError={isNameError}
+          errorText='2~5자로 입력해주세요.'
+        />
+        <AuthInput
+          label='아이디'
+          id='id'
+          value={id}
+          placeholder='아이디를 입력해주세요.'
+          onChange={(e) => handleIdChange(e.target.value)}
+          isError={isIdError}
+          errorText='영문, 숫자만 사용해 최소 6자 이상 입력해주세요.'
+        />
+        <AuthInput
+          label='비밀번호'
+          id='password'
+          type='password'
+          value={password}
+          placeholder='비밀번호를 입력해주세요.'
+          onChange={(e) => handlePasswordChange(e.target.value)}
+          isError={isPasswordError}
+          errorText='영문, 숫자를 포함해 최소 4자 이상 입력해주세요.'
+          className='mb-1'
+        />
+        <AuthInput
+          id='confirmPassword'
+          type='password'
+          value={passwordConfirm}
+          placeholder='비밀번호를 확인해주세요.'
+          onChange={(e) => handlePasswordConfirmChange(e.target.value)}
+          isError={isPasswordConfirmError}
+          errorText='비밀번호가 일치하지 않습니다.'
+        />
+      </div>
+      <div className='mt-14 text-center'>
+        <LargeButton text='회원가입' />
+      </div>
+    </form>
+  );
+};
+
+export default SignupForm;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,10 +1,30 @@
-export const Input = ({ id, placeHolder, onChange, disabled }) => {
+import React from 'react';
+
+interface Input {
+  readonly id: string;
+  readonly type?: string;
+  value: string;
+  readonly placeHolder: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  disabled: boolean;
+}
+
+export const Input = ({
+  id,
+  type,
+  value,
+  placeHolder,
+  onChange,
+  disabled,
+}: Input) => {
   return (
     <input
       id={id}
+      type={type}
+      value={value}
       placeholder={placeHolder}
-      onChange={(e) => onChange(e)}
-      className={`h-10 w-full pl-1 focus:outline-none border border-solid border-blue-gray-880`}
+      onChange={onChange}
+      className='w-full px-5 py-2.5 focus:outline-none border border-solid border-blue-gray-200 hover:border-blue-gray-400 focus:border-blue-gray-999 text-body-2 placeholder:text-blue-gray-200'
       disabled={disabled}
     ></input>
   );

--- a/src/components/common/TempHeader.tsx
+++ b/src/components/common/TempHeader.tsx
@@ -1,0 +1,40 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch, RootState } from '../../store';
+import { LargeButton } from './Button';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { logout } from '../../store/auth';
+import { Link } from 'react-router-dom';
+
+const TempHeader = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const dispatch = useDispatch<AppDispatch>();
+  const auth = useSelector((state: RootState) => state.auth);
+
+  const handleLogout = () => {
+    dispatch(logout());
+    navigate('/');
+  };
+
+  return (
+    <div className='flex justify-between px-10 py-4 border-b border-solid border-blue-gray-800 bg-blue-gray-10'>
+      <Link to='/' className='text-heading-1'>
+        고해성사
+      </Link>
+      <div className='flex items-center'>
+        <span className='text-subtitle-1 pr-2'>
+          {auth.user.loginId} {auth.user.name}
+        </span>
+        {auth.isLogin ? (
+          <LargeButton text={'로그아웃'} onClick={handleLogout} />
+        ) : location.pathname === '/login' ? (
+          <LargeButton text={'홈으로'} onClick={() => navigate('/')} />
+        ) : (
+          <LargeButton text={'로그인'} onClick={() => navigate('/login')} />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TempHeader;

--- a/src/components/post/PostInput.tsx
+++ b/src/components/post/PostInput.tsx
@@ -88,6 +88,7 @@ const PostInput = () => {
         >
           <Input
             id={'postTitle'}
+            value={state.title}
             placeHolder={'제목을 입력해 주세요'}
             disabled={false}
             onChange={(e) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,16 +4,24 @@ import App from './App';
 import { BrowserRouter } from 'react-router-dom';
 import './styles/index.css';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { Provider } from 'react-redux';
+import { PersistGate } from 'redux-persist/integration/react';
+import { store, persistor } from './store';
 
 const queryClient = new QueryClient();
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
+
 root.render(
-  <QueryClientProvider client={queryClient}>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </QueryClientProvider>,
+  <Provider store={store}>
+    <PersistGate loading={null} persistor={persistor}>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </PersistGate>
+  </Provider>,
 );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { RootState } from '../store';
+import HeadingText from '../components/auth/HeadingText';
+import LoginForm from '../components/auth/LoginForm';
+
+const LoginPage = () => {
+  const navigate = useNavigate();
+  const auth = useSelector((state: RootState) => state.auth);
+
+  useEffect(() => {
+    if (auth.isLogin) {
+      navigate('/');
+    }
+  }, []);
+
+  return (
+    <div className='pt-24'>
+      <HeadingText text='로그인' />
+      <LoginForm />
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,0 +1,13 @@
+import HeadingText from '../components/auth/HeadingText';
+import SignupForm from 'components/auth/SignupForm';
+
+const SignupPage = () => {
+  return (
+    <div className='pt-24'>
+      <HeadingText text='회원가입' />
+      <SignupForm />
+    </div>
+  );
+};
+
+export default SignupPage;

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -3,6 +3,7 @@ import Layout from '../components/common/Layout';
 import MainPage from '../pages/mainpage/MainPage';
 import PostPage from '../pages/PostPage';
 import LoginPage from '../pages/LoginPage';
+import SignupPage from '../pages/SignupPage';
 
 const Routes = () => {
   return (
@@ -11,6 +12,7 @@ const Routes = () => {
         <Route path='/' element={<MainPage />} />
         <Route path='/post' element={<PostPage />} />
         <Route path='/login' element={<LoginPage />} />
+        <Route path='/signup' element={<SignupPage />} />
         <Route path='*' element={<Navigate replace to='/' />} />
       </Route>
     </ReactRouters>

--- a/src/routes/Routes.tsx
+++ b/src/routes/Routes.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes as ReactRouters } from 'react-router-dom';
 import Layout from '../components/common/Layout';
 import MainPage from '../pages/mainpage/MainPage';
 import PostPage from '../pages/PostPage';
+import LoginPage from '../pages/LoginPage';
 
 const Routes = () => {
   return (
@@ -9,6 +10,7 @@ const Routes = () => {
       <Route element={<Layout />}>
         <Route path='/' element={<MainPage />} />
         <Route path='/post' element={<PostPage />} />
+        <Route path='/login' element={<LoginPage />} />
         <Route path='*' element={<Navigate replace to='/' />} />
       </Route>
     </ReactRouters>

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,0 +1,42 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+interface AuthState {
+  user: {
+    name: string;
+    userId: number;
+    loginId: string;
+  };
+  accessToken: string;
+  isLogin: boolean;
+}
+
+const initialState: AuthState = {
+  user: {
+    name: '',
+    userId: 0,
+    loginId: '',
+  },
+  accessToken: '',
+  isLogin: false,
+};
+
+export const auth = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    login(state, action) {
+      const { user, access_token } = action.payload;
+      return {
+        user,
+        accessToken: access_token.split(' ')[1],
+        isLogin: true,
+      };
+    },
+    logout() {
+      return initialState;
+    },
+  },
+});
+
+export const { login, logout } = auth.actions;
+export default auth.reducer;

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,0 +1,29 @@
+import { combineReducers } from 'redux';
+import { configureStore } from '@reduxjs/toolkit';
+import authReducer from './auth';
+import storage from 'redux-persist/lib/storage';
+import { persistReducer, persistStore } from 'redux-persist';
+
+const persistConfig = {
+  key: 'CURRENT_USER',
+  storage,
+  whitelist: ['auth'],
+};
+
+const rootReducer = combineReducers({
+  auth: authReducer,
+});
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
+
+export const store = configureStore({
+  reducer: persistedReducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({ serializableCheck: false }),
+  devTools: process.env.NODE_ENV !== 'production',
+});
+
+export const persistor = persistStore(store);
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -26,7 +26,7 @@
   }
 
   html {
-    @apply bg-blue-gray-25 text-blue-gray-990;
+    @apply bg-blue-gray-25 text-blue-gray-999;
     font-family: 'Noto Sans KR', sans-serif;
   }
 }
@@ -69,6 +69,7 @@
   }
 
   .text-subtitle-1 {
+    font-weight: 700;
     font-size: 14px;
     line-height: 24px;
   }
@@ -99,6 +100,11 @@
     @apply font-dgm;
     font-size: 10px;
     line-height: 14px;
+  }
+
+  .text-caption-2 {
+    font-size: 12px;
+    line-height: 16px;
   }
 
   .shadow-card-1 {


### PR DESCRIPTION
- 로그인, 회원가입 페이지 구현
- redux-persist 설치
- 리덕스로 로그인 정보 저장(auth)
- API 요청 헤더에 accessToken 추가

auth 확인을 위해 최상단에 [임시 헤더](https://github.com/prgrms-web-devcourse/FEDC4-Nextjs-Toyproject-Study/pull/19/files#diff-24143f5425b79d1dbfec3cbcc036618a14136001b0dc0acad2d49e350acdfccd) 추가했습니다. 헤더 작업 완료되면 삭제하겠습니다.