### PR TITLE
게시글(Post)에 redux 적용하기

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -15,7 +15,6 @@ const Header = () => {
   const dispatch = useDispatch<AppDispatch>();
   const auth = useSelector((state: RootState) => state.auth);
   const [isModalOpen, setIsModalOpen] = useState(false);
-
   const handleModal = () => {
     setIsModalOpen(!isModalOpen);
   };

--- a/src/components/mainpage/Post.tsx
+++ b/src/components/mainpage/Post.tsx
@@ -5,17 +5,6 @@ interface PostProps {
   post: PostType;
 }
 
-const template = {
-  red: '#FFCAC8',
-  pink: '#FBD0F5',
-  purple: '#B8B5FF',
-  blue: '#94DAFF',
-  sky: '#C7F5FE',
-  green: '#A3F7BF',
-  lime: '#DEFF8B',
-  yellow: '#F3F798',
-};
-
 const Post: React.FC<PostProps> = ({ post }) => {
   const template = post.templateType
     ? JSON.parse(post.templateType.replace(/'/g, '"'))
@@ -28,7 +17,7 @@ const Post: React.FC<PostProps> = ({ post }) => {
   return (
     <div
       className={`relative m-auto w-[268px] h-[386px] p-5 hover:shadow-[4px_4px_0px_0px_rgba(20,32,41,1)] hover:scale-105 `}
-      style={{ backgroundColor: template?.color }}
+      style={postStyle}
     >
       <div className='group/item absolute top-0 left-0 h-full w-full cursor-pointer flex justify-center items-center hover:bg-[#000000]/[.3] '>
         <div className='invisible absolute flex flex-row gap-4 group-hover/item:visible'>

--- a/src/components/mainpage/PostContainer.tsx
+++ b/src/components/mainpage/PostContainer.tsx
@@ -7,9 +7,15 @@ import { RootState } from 'store';
 import { getPosts, initPosts } from 'store/posts';
 interface PostContainerProps {
   handleModalClick: (postId) => void;
+  isCloseModal: boolean;
+  setIsCloseModal: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const PostContainer: React.FC<PostContainerProps> = ({ handleModalClick }) => {
+const PostContainer: React.FC<PostContainerProps> = ({
+  handleModalClick,
+  isCloseModal,
+  setIsCloseModal,
+}) => {
   const limit = 12;
   const endRef = useRef<HTMLDivElement>(null);
   const [start, setStart] = useState<number>(1);
@@ -44,8 +50,12 @@ const PostContainer: React.FC<PostContainerProps> = ({ handleModalClick }) => {
 
   useEffect(() => {
     dispatch(initPosts());
+    if (!isCloseModal) {
+      setStart((prev) => prev - 1);
+      setIsCloseModal(true);
+    }
     fetchData();
-  }, []);
+  }, [!isCloseModal]);
 
   useEffect(() => {
     if (!endRef.current) return;

--- a/src/components/mainpage/PostContainer.tsx
+++ b/src/components/mainpage/PostContainer.tsx
@@ -14,7 +14,6 @@ const PostContainer: React.FC<PostContainerProps> = ({ handleModalClick }) => {
   const endRef = useRef<HTMLDivElement>(null);
   const [start, setStart] = useState<number>(1);
   // const [datas, setDatas] = useState<PostType[]>([]);
-
   const dispatch = useDispatch();
   const datas: PostType[] = useSelector((state: RootState) => state.posts);
 

--- a/src/components/mainpage/PostContainer.tsx
+++ b/src/components/mainpage/PostContainer.tsx
@@ -2,6 +2,8 @@ import Post from './Post';
 import { useEffect, useRef, useState } from 'react';
 import { getPost } from 'api/postApi';
 import { PostType } from 'interface/index';
+import { useSelector } from 'react-redux';
+import { RootState } from 'store';
 interface PostContainerProps {
   handleModalClick: (postId) => void;
 }
@@ -12,11 +14,15 @@ const PostContainer: React.FC<PostContainerProps> = ({ handleModalClick }) => {
   const [start, setStart] = useState<number>(1);
   const [datas, setDatas] = useState<PostType[]>([]);
 
+  const posts = useSelector((state: RootState) => state.posts);
+  console.log(posts);
+
   const fetchData = async () => {
     try {
       const response = await getPost({ pageId: start, limitNumber: limit });
       setDatas([...datas, ...response.data]);
       setStart(start + 1);
+      console.log(response.data);
     } catch (error) {
       alert(error);
       console.error('Error fetching data.');

--- a/src/components/mainpage/PostContainer.tsx
+++ b/src/components/mainpage/PostContainer.tsx
@@ -2,8 +2,9 @@ import Post from './Post';
 import { useEffect, useRef, useState } from 'react';
 import { getPost } from 'api/postApi';
 import { PostType } from 'interface/index';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from 'store';
+import { getPosts, initPosts } from 'store/posts';
 interface PostContainerProps {
   handleModalClick: (postId) => void;
 }
@@ -12,17 +13,17 @@ const PostContainer: React.FC<PostContainerProps> = ({ handleModalClick }) => {
   const limit = 12;
   const endRef = useRef<HTMLDivElement>(null);
   const [start, setStart] = useState<number>(1);
-  const [datas, setDatas] = useState<PostType[]>([]);
+  // const [datas, setDatas] = useState<PostType[]>([]);
 
-  const posts = useSelector((state: RootState) => state.posts);
-  console.log(posts);
+  const dispatch = useDispatch();
+  const datas: PostType[] = useSelector((state: RootState) => state.posts);
 
   const fetchData = async () => {
     try {
       const response = await getPost({ pageId: start, limitNumber: limit });
-      setDatas([...datas, ...response.data]);
+      // setDatas([...datas, ...response.data]);
       setStart(start + 1);
-      console.log(response.data);
+      dispatch(getPosts(response.data));
     } catch (error) {
       alert(error);
       console.error('Error fetching data.');
@@ -43,6 +44,7 @@ const PostContainer: React.FC<PostContainerProps> = ({ handleModalClick }) => {
   };
 
   useEffect(() => {
+    dispatch(initPosts());
     fetchData();
   }, []);
 

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -8,6 +8,7 @@ const MainPage: React.FC = () => {
     showModal: true,
   };
   const [state, setState] = useState(initialState);
+  const [isCloseModal, setIsCloseModal] = useState(true);
 
   const clickModal = ({ postId }) => {
     setState({ postId: postId, showModal: !state.showModal });
@@ -19,9 +20,9 @@ const MainPage: React.FC = () => {
       if (e.key === 'Escape') {
         setState({ postId: null, showModal: true });
         document.body.style.overflow = 'unset';
+        setIsCloseModal(false);
       }
     };
-
     document.addEventListener('keydown', handleEscape);
 
     return () => {
@@ -31,7 +32,11 @@ const MainPage: React.FC = () => {
 
   return (
     <div>
-      <PostContainer handleModalClick={clickModal} />
+      <PostContainer
+        handleModalClick={clickModal}
+        isCloseModal={isCloseModal}
+        setIsCloseModal={setIsCloseModal}
+      />
       {
         <Modal
           modalOption={state}
@@ -39,6 +44,7 @@ const MainPage: React.FC = () => {
             if (event.target.id === 'background') {
               setState({ postId: null, showModal: true });
               document.body.style.overflow = 'unset';
+              setIsCloseModal(false);
             }
           }}
           closeBtnClick={(event) => {

--- a/src/pages/Modal/Modal.tsx
+++ b/src/pages/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect } from 'react';
+import { FC, useState, useEffect } from 'react';
 import ImageView from './ImageView/ImageView';
 import Comment from './Comment/Comments';
 import { getPostDetail } from 'api/postApi';
@@ -45,10 +45,6 @@ const Modal: FC<ModalProps> = ({ closeBtnClick, modalOption, closeModal }) => {
   useEffect(() => {
     fetchData();
   }, [postId]);
-
-  // if (state.isLoading) {
-  //   return <div>Loading...</div>;
-  // }
 
   const isPc = useMediaQuery({
     query: '(min-width:1115px)',

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,4 +1,3 @@
-import { combineReducers } from 'redux';
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from './auth';
 import storage from 'redux-persist/lib/storage';
@@ -10,14 +9,10 @@ const persistConfig = {
   whitelist: ['auth'],
 };
 
-const rootReducer = combineReducers({
-  auth: authReducer,
-});
-
-const persistedReducer = persistReducer(persistConfig, rootReducer);
+const persistedReducer = persistReducer(persistConfig, authReducer);
 
 export const store = configureStore({
-  reducer: persistedReducer,
+  reducer: { auth: persistedReducer },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({ serializableCheck: false }),
   devTools: process.env.NODE_ENV !== 'production',

--- a/src/store/index.tsx
+++ b/src/store/index.tsx
@@ -1,7 +1,14 @@
+import { combineReducers } from '@reduxjs/toolkit';
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from './auth';
+import postsReducer from './posts';
 import storage from 'redux-persist/lib/storage';
 import { persistReducer, persistStore } from 'redux-persist';
+
+const rootReducer = combineReducers({
+  auth: authReducer,
+  posts: postsReducer,
+});
 
 const persistConfig = {
   key: 'CURRENT_USER',
@@ -9,10 +16,10 @@ const persistConfig = {
   whitelist: ['auth'],
 };
 
-const persistedReducer = persistReducer(persistConfig, authReducer);
+const persistedReducer = persistReducer(persistConfig, rootReducer);
 
 export const store = configureStore({
-  reducer: { auth: persistedReducer },
+  reducer: persistedReducer,
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({ serializableCheck: false }),
   devTools: process.env.NODE_ENV !== 'production',

--- a/src/store/posts.ts
+++ b/src/store/posts.ts
@@ -1,28 +1,21 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { PostType } from '../interface/index';
 
-const initialState: Array<PostType> = [
-  {
-    postId: 123,
-    title: 'imsy',
-    content: 'zzz',
-    user: { name: 'haya', nickName: 'haya2' },
-    commentCount: 1,
-    likeCount: 0,
-    forgiveCount: 0,
-  },
-];
+const initialState: PostType[] = [];
 
 export const posts = createSlice({
   name: 'posts',
   initialState,
   reducers: {
     getPosts(state, action) {
-      const { postsData } = action.payload;
-      state = [...state, postsData];
+      const postsData = action.payload;
+      return [...state, ...postsData];
+    },
+    initPosts() {
+      return initialState;
     },
   },
 });
 
-export const { getPosts } = posts.actions;
+export const { getPosts, initPosts } = posts.actions;
 export default posts.reducer;

--- a/src/store/posts.ts
+++ b/src/store/posts.ts
@@ -1,0 +1,28 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { PostType } from '../interface/index';
+
+const initialState: Array<PostType> = [
+  {
+    postId: 123,
+    title: 'imsy',
+    content: 'zzz',
+    user: { name: 'haya', nickName: 'haya2' },
+    commentCount: 1,
+    likeCount: 0,
+    forgiveCount: 0,
+  },
+];
+
+export const posts = createSlice({
+  name: 'posts',
+  initialState,
+  reducers: {
+    getPosts(state, action) {
+      const { postsData } = action.payload;
+      state = [...state, postsData];
+    },
+  },
+});
+
+export const { getPosts } = posts.actions;
+export default posts.reducer;


### PR DESCRIPTION
## 구현 기능

- 메인페이지에 불러오는 포스트 데이터를 redux에 넣고, 불러서 렌더링 시킴.
- Modal을 닫을 때, redux의 데이터를 refetch하여 새롭게 렌더링 시킴. (좋아요, 댓글 수 변동 바로 적용)